### PR TITLE
Pin wire-webapp-proteus version to 3.0.x.

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "libsodium-wrappers": "^0.4.8",
     "protocol-buffers": "^3.2.1",
     "uuid": "^3.0.1",
-    "wire-webapp-proteus": "^3.0.3"
+    "wire-webapp-proteus": "~3.0.3"
   },
   "devDependencies": {
     "eslint": "^3.13.1",


### PR DESCRIPTION
Fixes issue #3.